### PR TITLE
LGTM: default to 'pending' rather than 'failure'

### DIFF
--- a/lgtm/status_cache.go
+++ b/lgtm/status_cache.go
@@ -87,7 +87,7 @@ func getStatus(context *ctx.Context, ref prRef) (*statusInfo, error) {
 func newEmptyStatus(owner string, quorum int) *github.RepoStatus {
 	return &github.RepoStatus{
 		Context:     github.String(lgtmContext(owner)),
-		State:       github.String("failure"),
+		State:       github.String("pending"),
 		Description: github.String(statusInfo{quorum: quorum}.newDescription()),
 	}
 }

--- a/lgtm/status_cache_test.go
+++ b/lgtm/status_cache_test.go
@@ -285,7 +285,7 @@ func TestNewEmptyStatus(t *testing.T) {
 	for _, test := range cases {
 		status := newEmptyStatus(test.owner, 1)
 		assert.Equal(t, test.expContext, *status.Context)
-		assert.Equal(t, "failure", *status.State)
+		assert.Equal(t, "pending", *status.State)
 		assert.Equal(t, "Awaiting approval from at least 1 maintainer.", *status.Description)
 	}
 }

--- a/lgtm/status_info.go
+++ b/lgtm/status_info.go
@@ -69,7 +69,7 @@ func (s statusInfo) newState() string {
 	if len(s.lgtmers) >= s.quorum {
 		return "success"
 	}
-	return "failure"
+	return "pending"
 }
 
 // newDescription produces the LGTM status description based on the LGTMers

--- a/lgtm/status_info_test.go
+++ b/lgtm/status_info_test.go
@@ -64,11 +64,11 @@ func TestNewState(t *testing.T) {
 		expected string
 	}{
 		{[]string{}, 0, "success"},
-		{[]string{}, 1, "failure"},
-		{[]string{}, 2, "failure"},
+		{[]string{}, 1, "pending"},
+		{[]string{}, 2, "pending"},
 		{[]string{"@parkr"}, 0, "success"},
 		{[]string{"@parkr"}, 1, "success"},
-		{[]string{"@parkr"}, 2, "failure"},
+		{[]string{"@parkr"}, 2, "pending"},
 		{[]string{"@parkr", "@mattr-"}, 0, "success"},
 		{[]string{"@parkr", "@mattr-"}, 1, "success"},
 		{[]string{"@parkr", "@mattr-"}, 2, "success"},
@@ -137,12 +137,12 @@ func TestStatusInfoNewRepoStatus(t *testing.T) {
 	}{
 		{"octocat", []string{}, 0, "octocat/lgtm", "success", "No approval is required."},
 		{"parkr", []string{}, 0, "parkr/lgtm", "success", "No approval is required."},
-		{"jekyll", []string{}, 1, "jekyll/lgtm", "failure", "Awaiting approval from at least 1 maintainer."},
+		{"jekyll", []string{}, 1, "jekyll/lgtm", "pending", "Awaiting approval from at least 1 maintainer."},
 		{"jekyll", []string{"@parkr"}, 1, "jekyll/lgtm", "success", "Approved by @parkr."},
-		{"jekyll", []string{"@parkr"}, 2, "jekyll/lgtm", "failure", "Approved by @parkr. Requires 1 more LGTM."},
+		{"jekyll", []string{"@parkr"}, 2, "jekyll/lgtm", "pending", "Approved by @parkr. Requires 1 more LGTM."},
 		{"jekyll", []string{"@parkr", "@envygeeks"}, 1, "jekyll/lgtm", "success", "Approved by @parkr and @envygeeks."},
 		{"jekyll", []string{"@parkr", "@envygeeks"}, 2, "jekyll/lgtm", "success", "Approved by @parkr and @envygeeks."},
-		{"jekyll", []string{"@parkr", "@mattr-", "@envygeeks"}, 6, "jekyll/lgtm", "failure", "Approved by @parkr, @mattr-, and @envygeeks. Requires 3 more LGTM's."},
+		{"jekyll", []string{"@parkr", "@mattr-", "@envygeeks"}, 6, "jekyll/lgtm", "pending", "Approved by @parkr, @mattr-, and @envygeeks. Requires 3 more LGTM's."},
 	}
 	for _, test := range cases {
 		status := statusInfo{lgtmers: test.lgtmers, quorum: test.quorum}


### PR DESCRIPTION
The 'pending' status seems more semantically correct since there are two
states: 'pending' LGTMs from maintainers or 'success'fully receiving the
required amount of LGTMs.