### PR TITLE
Add has-pull-request label

### DIFF
--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -1,0 +1,56 @@
+package labeler
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/google/go-github/github"
+	"github.com/parkr/auto-reply/common"
+	"github.com/parkr/auto-reply/ctx"
+)
+
+const repoMergeabilitayCheckWaitSec = 2
+
+var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
+	event, ok := payload.(*github.PullRequestEvent)
+	if !ok {
+		return context.NewError("PendingRebaseUnlabeler: not a pull request event")
+	}
+
+	if *event.Action != "synchronize" {
+		return nil
+	}
+
+	owner, repo, num := *event.Repo.Owner.Login, *event.Repo.Name, *event.Number
+
+	// Allow the job to run which determines mergeability.
+	log.Printf("checking the mergeabilitay of %s/%s#%d in %d sec...", owner, repo, num, repoMergeabilitayCheckWaitSec)
+	time.Sleep(repoMergeabilitayCheckWaitSec * time.Second)
+
+	var err error
+	if isMergeablee(context, owner, repo, num) {
+		err = RemoveLabelIfExists(context.GitHub, owner, repo, num, "has-pull-request")
+		if err != nil {
+			log.Printf("error removing the has-pull-request label: %v", err)
+		}
+		err = RemoveLabelIfExists(context.GitHub, owner, repo, num, "needs-work")
+	} else {
+		err = fmt.Errorf("%s/%s#%d is not mergeable", owner, repo, num)
+	}
+
+	if err != nil {
+		log.Printf("error removing the pending-rebase & needs-work labels: %v", err)
+	}
+	return err
+}
+
+func isMergeablee(context *ctx.Context, owner, repo string, number int) bool {
+	pr, res, err := context.GitHub.PullRequests.Get(owner, repo, number)
+	err = common.ErrorFromResponse(res, err)
+	if err != nil {
+		log.Printf("couldn't determine mergeability of %s/%s#%d: %v", owner, repo, number, err)
+		return false
+	}
+	return *pr.Mergeable
+}

--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -9,7 +9,7 @@ import (
 	"github.com/parkr/auto-reply/ctx"
 )
 
-var fixesIssueMatcher = regexp.MustCompile(`(?:Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved) #(\d+)`)
+var fixesIssueMatcher = regexp.MustCompile(`(?i)(?:Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved) #(\d+)`)
 
 var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
 	event, ok := payload.(*github.PullRequestEvent)

--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -9,7 +9,7 @@ import (
 	"github.com/parkr/auto-reply/ctx"
 )
 
-var fixesIssueMatcher = regexp.MustCompile(`(Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved) #(\d+)`)
+var fixesIssueMatcher = regexp.MustCompile(`(?:Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved) #(\d+)`)
 
 var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
 	event, ok := payload.(*github.PullRequestEvent)

--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -1,56 +1,41 @@
 package labeler
 
 import (
-	"fmt"
 	"log"
-	"time"
+	"regexp"
 
 	"github.com/google/go-github/github"
-	"github.com/parkr/auto-reply/common"
 	"github.com/parkr/auto-reply/ctx"
 )
 
-const repoMergeabilitayCheckWaitSec = 2
+var fixesIssueMatcher = regexp.MustCompile(`Fixes #(\d+)`)
 
 var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
 	event, ok := payload.(*github.PullRequestEvent)
 	if !ok {
-		return context.NewError("PendingRebaseUnlabeler: not a pull request event")
+		return context.NewError("IssueHasPullRequestLabeler: not a pull request event")
 	}
 
-	if *event.Action != "synchronize" {
+	if *event.Action != "opened" {
 		return nil
 	}
 
-	owner, repo, num := *event.Repo.Owner.Login, *event.Repo.Name, *event.Number
-
-	// Allow the job to run which determines mergeability.
-	log.Printf("checking the mergeabilitay of %s/%s#%d in %d sec...", owner, repo, num, repoMergeabilitayCheckWaitSec)
-	time.Sleep(repoMergeabilitayCheckWaitSec * time.Second)
+        description := *event.PullRequest.Body
+	issueNum := issueFixed(description)
 
 	var err error
-	if isMergeablee(context, owner, repo, num) {
-		err = RemoveLabelIfExists(context.GitHub, owner, repo, num, "has-pull-request")
-		if err != nil {
-			log.Printf("error removing the has-pull-request label: %v", err)
-		}
-		err = RemoveLabelIfExists(context.GitHub, owner, repo, num, "needs-work")
-	} else {
-		err = fmt.Errorf("%s/%s#%d is not mergeable", owner, repo, num)
+	if issueNum != "" {
+		log.Printf("detected a pull request that fixes issue %v", issueNum)
 	}
 
-	if err != nil {
-		log.Printf("error removing the pending-rebase & needs-work labels: %v", err)
-	}
 	return err
 }
 
-func isMergeablee(context *ctx.Context, owner, repo string, number int) bool {
-	pr, res, err := context.GitHub.PullRequests.Get(owner, repo, number)
-	err = common.ErrorFromResponse(res, err)
-	if err != nil {
-		log.Printf("couldn't determine mergeability of %s/%s#%d: %v", owner, repo, number, err)
-		return false
+func issueFixed(description string) string {
+	issueSubmatches := fixesIssueMatcher.FindAllStringSubmatch(description, -1)
+	if len(issueSubmatches) == 0 || len(issueSubmatches[0]) < 2 {
+		return ""
 	}
-	return *pr.Mergeable
+
+	return issueSubmatches[0][1]
 }

--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -9,7 +9,7 @@ import (
 	"github.com/parkr/auto-reply/ctx"
 )
 
-var fixesIssueMatcher = regexp.MustCompile(`Fixes #(\d+)`)
+var fixesIssueMatcher = regexp.MustCompile(`(Clos|Fix|Resolv)(e|es|ed) #(\d+)`)
 
 var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
 	event, ok := payload.(*github.PullRequestEvent)

--- a/labeler/has_pull_request.go
+++ b/labeler/has_pull_request.go
@@ -9,7 +9,7 @@ import (
 	"github.com/parkr/auto-reply/ctx"
 )
 
-var fixesIssueMatcher = regexp.MustCompile(`(Clos|Fix|Resolv)(e|es|ed) #(\d+)`)
+var fixesIssueMatcher = regexp.MustCompile(`(Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved) #(\d+)`)
 
 var IssueHasPullRequestLabeler = func(context *ctx.Context, payload interface{}) error {
 	event, ok := payload.(*github.PullRequestEvent)

--- a/labeler/has_pull_request_test.go
+++ b/labeler/has_pull_request_test.go
@@ -14,4 +14,8 @@ func TestClosedIssueRegex(t *testing.T) {
         assert.Equal(t, "13",
           fixesIssueMatcher.FindAllStringSubmatch("Closed #13", -1)[0][1],
           "should match 'close' pattern too 'Closed #13'")
+
+        assert.Equal(t, "13",
+          fixesIssueMatcher.FindAllStringSubmatch("rEsoLvEd #13", -1)[0][1],
+          "should match mixedcase pattern")
 }

--- a/labeler/has_pull_request_test.go
+++ b/labeler/has_pull_request_test.go
@@ -1,0 +1,17 @@
+package labeler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClosedIssueRegex(t *testing.T) {
+        assert.Equal(t, "13",
+          fixesIssueMatcher.FindAllStringSubmatch("Fixes #13", -1)[0][1],
+          "should have extracted 13 from 'Fixes #13'")
+
+        assert.Equal(t, "13",
+          fixesIssueMatcher.FindAllStringSubmatch("Closed #13", -1)[0][1],
+          "should match 'close' pattern too 'Closed #13'")
+}


### PR DESCRIPTION
Fixes #11 

Known limitations:

- does not handle closing of pull requests: issue will keep "has-pull-request" label even if the fixing PR gets rejected/closed by the OP
- does not handle multiple "fixes"
- does not handle edits: if the "fixes" line is added after the fact, the bot won't see it
- very limited unit tests

Interesting tests that I didn't run:
- check what happens when the repo does not have the "has-pull-request" label

Demo: https://github.com/thiagoarrais/ignore-this/issues/6