### PR TITLE
File issue on GitHub for each constraint that's holding us up.

### DIFF
--- a/cmd/check-for-outdated-dependencies/main.go
+++ b/cmd/check-for-outdated-dependencies/main.go
@@ -24,13 +24,28 @@ func main() {
 
 	for _, repo := range strings.Split(reposString, ",") {
 		pieces := strings.SplitN(repo, "/", 2)
-		checker := dependencies.NewRubyDependencyChecker(pieces[0], pieces[1])
+		repoOwner, repoName := pieces[0], pieces[1]
+		checker := dependencies.NewRubyDependencyChecker(repoOwner, repoName)
 		outdated := checker.AllOutdatedDependencies(context)
 		for _, dependency := range outdated {
 			log.Printf(
 				"%s/%s: %s is outdated (constraint: %s, but latest version is %s)",
-				pieces[0], pieces[1], dependency.GetName(), dependency.GetConstraint(), dependency.GetLatestVersion(context),
+				repoOwner, repoName, dependency.GetName(), dependency.GetConstraint(), dependency.GetLatestVersion(context),
 			)
+
+			preExistingIssue := dependencies.GitHubUpdateIssueForDependency(context, repoOwner, repoName, dependency)
+
+			if preExistingIssue == nil {
+				issue, err := dependencies.FileGitHubIssueForDependency(context, repoOwner, repoName, dependency)
+				if err != nil {
+					log.Printf("%s/%s: error creating issue for %s: %v", repoOwner, repoName, dependency.GetName(), err)
+				} else {
+					log.Printf("%s/%s: issue for %s filed: %s", repoOwner, repoName, dependency.GetName(), *issue.HTMLURL)
+				}
+			} else {
+				log.Printf("%s/%s: issue for %s already open: %s",
+					repoOwner, repoName, dependency.GetName(), *preExistingIssue.HTMLURL)
+			}
 		}
 	}
 }

--- a/dependencies/github.go
+++ b/dependencies/github.go
@@ -1,0 +1,56 @@
+package dependencies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/parkr/auto-reply/ctx"
+)
+
+func containsSubstring(s, substring string) bool {
+	return strings.Index(strings.ToLower(s), strings.ToLower(substring)) >= 0
+}
+
+func GitHubUpdateIssueForDependency(context *ctx.Context, repoOwner, repoName string, dependency Dependency) *github.Issue {
+	query := fmt.Sprintf(
+		"repo:%s/%s update %s v%s is:open in:title",
+		repoOwner, repoName, dependency.GetName(), dependency.GetLatestVersion(context))
+	opts := &github.SearchOptions{Sort: "created", Order: "desc", ListOptions: github.ListOptions{Page: 0, PerPage: 100}}
+	for {
+		result, resp, err := context.GitHub.Search.Issues(query, opts)
+		if err != nil {
+			context.Log("dependencies: error running search query: '%s': %v", query, err)
+			break
+		}
+
+		for _, issue := range result.Issues {
+			if containsSubstring(*issue.Title, "update") && containsSubstring(*issue.Title, dependency.GetName()) {
+				return &issue
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.ListOptions.Page = resp.NextPage
+	}
+
+	return nil
+}
+
+func FileGitHubIssueForDependency(context *ctx.Context, repoOwner, repoName string, dependency Dependency) (*github.Issue, error) {
+	issue, _, err := context.GitHub.Issues.Create(repoOwner, repoName, &github.IssueRequest{
+		Title: github.String(fmt.Sprintf(
+			"Update dependency constraint to allow for %s v%s",
+			dependency.GetName(), dependency.GetLatestVersion(context),
+		)),
+		Body: github.String(fmt.Sprintf(
+			"Hey there! :wave:\n\nI noticed that the constraint you have for %s doesn't allow for the latest version to be used.\n\nThe constraint I found was `%s`, and the latest version available is `%s`.\n\nCan you look into updating that constraint so our users can use the latest and greatest version? Thanks! :revolving_hearts:",
+			dependency.GetName(), dependency.GetConstraint(), dependency.GetLatestVersion(context),
+		)),
+		Labels: &[]string{"help-wanted", "dependency"},
+	})
+	return issue, err
+}


### PR DESCRIPTION
Just ran it on `jekyll/jekyll` and it looks good:

main.go:34: jekyll/jekyll: liquid is outdated (constraint: ~> 3.0, but latest version is 4.0.0)
main.go:47: jekyll/jekyll: issue for liquid already open: https://github.com/jekyll/jekyll/issues/5772
main.go:34: jekyll/jekyll: rouge is outdated (constraint: ~> 1.7, but latest version is 2.0.7)
main.go:43: jekyll/jekyll: issue for rouge filed: https://github.com/jekyll/jekyll/issues/5774
main.go:34: jekyll/jekyll: codeclimate-test-reporter is outdated (constraint: ~> 0.6.0, but latest version is 1.0.4)
main.go:43: jekyll/jekyll: issue for codeclimate-test-reporter filed: https://github.com/jekyll/jekyll/issues/5775
main.go:34: jekyll/jekyll: rdoc is outdated (constraint: ~> 4.2, but latest version is 5.0.0)
main.go:43: jekyll/jekyll: issue for rdoc filed: https://github.com/jekyll/jekyll/issues/5776
main.go:34: jekyll/jekyll: html-proofer is outdated (constraint: ~> 2.0, but latest version is 3.4.0)
main.go:43: jekyll/jekyll: issue for html-proofer filed: https://github.com/jekyll/jekyll/issues/5777
main.go:34: jekyll/jekyll: jemoji is outdated (constraint: 0.5.1, but latest version is 0.7.0)
main.go:43: jekyll/jekyll: issue for jemoji filed: https://github.com/jekyll/jekyll/issues/5778