### PR TITLE
Check for new dependencies on jekyll-watch plugin

### DIFF
--- a/cmd/check-for-outdated-dependencies/main.go
+++ b/cmd/check-for-outdated-dependencies/main.go
@@ -12,6 +12,7 @@ import (
 
 var defaultRepos = strings.Join([]string{
 	"jekyll/jekyll",
+	"jekyll/jekyll-watch",
 }, ",")
 
 func main() {


### PR DESCRIPTION
We decided to bump `jekyll-watch` [to version 2.0](https://github.com/jekyll/jekyll-watch/issues/54) so it might be the right time for @jekyllbot to open some dependencies issues.