### PR TITLE
Disable stale for release

### DIFF
--- a/cmd/mark-and-sweep-stale-issues/mark_and_sweep_stale_issues.go
+++ b/cmd/mark-and-sweep-stale-issues/mark_and_sweep_stale_issues.go
@@ -30,6 +30,7 @@ var (
 	nonStaleableLabels = []string{
 		"has-pull-request",
 		"pinned",
+		"release",
 		"security",
 	}
 


### PR DESCRIPTION
Given we add the "release" label on the reminder, we should also add it to the list of labels that can't be marked as stale.

