### PR TITLE
fix: nudge maintainers only every 3 months

### DIFF
--- a/cmd/nudge-maintainers-to-release/main.go
+++ b/cmd/nudge-maintainers-to-release/main.go
@@ -23,7 +23,7 @@ import (
 var (
 	defaultRepos = jekyll.DefaultRepos
 
-	twoMonthsAgoUnix = time.Now().AddDate(0, -2, 0).Unix()
+	threeMonthsAgoUnix = time.Now().AddDate(0, -3, 0).Unix()
 
 	issueTitle  = "Time for a new release"
 	issueLabels = []string{"release"}
@@ -31,7 +31,7 @@ var (
 	issueBodyTemplate = template.Must(template.New("issueBodyTemplate").Parse(`
 Hello, maintainers! :wave:
 
-By my calculations, it's time for a new release of {{.Repo.Name}}. {{if gt .CommitsOnMasterSinceLatestRelease 100}}There have been {{.CommitsOnMasterSinceLatestRelease}} commits{{else}}It's been over 2 months{{end}} since the last release, {{.LatestRelease.TagName}}.
+By my calculations, it's time for a new release of {{.Repo.Name}}. {{if gt .CommitsOnMasterSinceLatestRelease 100}}There have been {{.CommitsOnMasterSinceLatestRelease}} commits{{else}}It's been over 3 months{{end}} since the last release, {{.LatestRelease.TagName}}.
 
 What else is left to be done before a new release can be made? Please make sure to update History.markdown too if it's not already updated.
 
@@ -110,7 +110,7 @@ func main() {
 					return err
 				}
 
-				if commitsSinceLatestRelease > 100 || (commitsSinceLatestRelease >= 1 && latestRelease.GetCreatedAt().Unix() <= twoMonthsAgoUnix) {
+				if commitsSinceLatestRelease > 100 || (commitsSinceLatestRelease >= 3 && latestRelease.GetCreatedAt().Unix() <= threeMonthsAgoUnix) {
 					if perform {
 						err := fileIssue(context, templateInfo{
 							Repo:                              repo,


### PR DESCRIPTION
Given Jekyll's team current pace, 2 months is often a too short period, especially for plugins, there's not necessarily changes to releases. 

As a maintainer, I would feel more comfortable if nudges were addressed only once every 3 months.(it's already very optimistic for most plugins).

/cc @parkr 