### PR TITLE
unify-labels: skip archived repos

### DIFF
--- a/cmd/unify-labels/unify_labels.go
+++ b/cmd/unify-labels/unify_labels.go
@@ -146,6 +146,9 @@ func main() {
 		}
 
 		for _, repo := range repos {
+			if repo.GetArchived() {
+				continue // skip archived repos
+			}
 			if err := processRepo(context, repo, perform); err != nil {
 				context.Log("%s: failed!", *repo.FullName)
 				return err


### PR DESCRIPTION
This fixes an error where we were trying to run this on jekyll-help, which is archived.

https://sentry.io/organizations/app39225255herokucom/issues/413004347/